### PR TITLE
Remove message generation and runtime from package.xml

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -43,12 +43,10 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>std_msgs</build_depend>
-  <build_depend>message_generation</build_depend>
   <build_depend>libusb</build_depend>
   <build_depend>libusb-dev</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>std_msgs</run_depend>
-  <run_depend>message_runtime</run_depend>
   <run_depend>libusb</run_depend>
   <run_depend>libusb-dev</run_depend>
 


### PR DESCRIPTION
This causes a `catkin_lint` issue since they are not actually required deps.